### PR TITLE
feat: Add looping and fading to audio system

### DIFF
--- a/include/audio.h
+++ b/include/audio.h
@@ -2,6 +2,7 @@
 #define AUDIO_H
 
 #include "raylib.h"
+#include <stdbool.h>
 
 // Enum for different sound effects
 typedef enum {
@@ -28,5 +29,11 @@ void Audio_PlayMusic(MusicTrack music);
 void Audio_UpdateMusic(void); // Needed for music streaming
 
 void Audio_SetMasterVolume(float volume);
+
+// New functions for looping and fading
+void Audio_SetMusicLoop(MusicTrack music_track, bool loop);
+void Audio_FadeInMusic(MusicTrack music_track, float duration);
+void Audio_FadeOutMusic(float duration);
+
 
 #endif // AUDIO_H

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@ int main(void) {
     const int screenWidth = 800;
     const int screenHeight = 450;
 
-    InitWindow(screenWidth, screenHeight, "Input and Audio System Example");
+    InitWindow(screenWidth, screenHeight, "Audio System Example");
     SetTargetFPS(60);
 
     // Initialize systems
@@ -18,7 +18,8 @@ int main(void) {
     Audio_LoadSound(SOUND_EFFECT_ATTACK, "assets/attack.wav");
     Audio_LoadMusic(MUSIC_TRACK_BACKGROUND, "assets/background.mp3");
 
-    // Play background music
+    // Set music to loop and play
+    Audio_SetMusicLoop(MUSIC_TRACK_BACKGROUND, true);
     Audio_PlayMusic(MUSIC_TRACK_BACKGROUND);
 
     // Create a player rectangle
@@ -47,11 +48,20 @@ int main(void) {
             Audio_PlaySound(SOUND_EFFECT_ATTACK); // Play attack sound
         }
 
+        // Test fading
+        if (IsKeyPressed(KEY_O)) {
+            Audio_FadeOutMusic(2.0f); // Fade out over 2 seconds
+        }
+        if (IsKeyPressed(KEY_I)) {
+            Audio_FadeInMusic(MUSIC_TRACK_BACKGROUND, 2.0f); // Fade in over 2 seconds
+        }
+
         // Draw
         BeginDrawing();
         ClearBackground(RAYWHITE);
         DrawRectangleRec(player, RED);
-        DrawText("Use WASD, Gamepad Left Stick, or Mouse Click", 10, 10, 20, DARKGRAY);
+        DrawText("Use WASD, Gamepad, or Mouse Click", 10, 10, 20, DARKGRAY);
+        DrawText("Press 'O' to fade out music, 'I' to fade in", 10, 40, 20, DARKGRAY);
         EndDrawing();
     }
 


### PR DESCRIPTION
This commit enhances the audio system with two new features:
- Music looping: Music tracks can now be set to loop continuously.
- Music fading: Music tracks can be faded in and out smoothly over a specified duration.

The implementation includes:
- A state machine to manage the looping and fading state of each music track.
- New API functions (`Audio_SetMusicLoop`, `Audio_FadeInMusic`, `Audio_FadeOutMusic`) to control these features.
- Updates to the main application to test the new functionality.